### PR TITLE
Color nodes based on HTML type and modify Visualize.js (Zoom, Node spacing, and Tooltip) 

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,23 +1,22 @@
+
 /* eslint-disable max-len */
 /* eslint-disable require-jsdoc */
-'use strict';
+"use strict";
 
 // TODO consider if using d3.select("svg").size() == 0 instead is a good idea
-let isTreeOnDOM = false;
 
 function generateDOMTree(userInputString) {
   const parserOutputNode = parseHTML(userInputString);
   if (parserOutputNode !== null) {
     const d3TreeData = levelOrderTraversal(parserOutputNode);
-    const DOMTreeRootNode = d3TreeData[0];
-    // TODO performance: cache the previous input string to check
-    // if the current string is the same before traversing the DOM Tree
-    if (isTreeOnDOM === false) {
-      createAndAppendDOMTree(DOMTreeRootNode);
-      isTreeOnDOM = true;
+    const DOMTreeRootNode = d3TreeData;
+
+    if (d3.select('svg').size() === 0) {
+      new DOMTree(DOMTreeRootNode);
     } else {
-      removeNodes();
-      createAndAppendDOMTree(DOMTreeRootNode);
+      d3.select('svg').remove();
+      d3.select('div.tooltip').remove();
+      new DOMTree(DOMTreeRootNode);
     }
   } else {
     // TODO remove this exception when we add try catch block to parseHTML
@@ -38,10 +37,8 @@ function parseHTML(userInputString) {
 
 function levelOrderTraversal(rootNode) {
   // Level order traverse the output of DOMParser
-  const resultArray = [{
-    name: 'HTML',
-    children: [],
-  }];
+  const resultArray = [{name: 'HTML', children: [],
+    type: 'Doctype', color: '#CBEEF3'}];
   levelOrderTraversalHelper(rootNode, resultArray[0].children, resultArray);
   return resultArray;
 }
@@ -60,12 +57,16 @@ function levelOrderTraversalHelper(node, childrenArr, outputArray) {
     const isNotHTMLNode = node.parentNode.nodeName !== '#document';
     const currentNodeElementName = node.tagName;
     const currentNodeParentElementName = node.parentNode.tagName;
+    const {type, color} = determineType(currentNodeElementName);
+
     if (isNotHTMLNode) {
       childrenArr.push({
         name: currentNodeElementName,
         parent: currentNodeParentElementName,
         children: [],
         obj: node,
+        type: type,
+        color: color,
       });
     } else if (isLeaf) {
       childrenArr.push({
@@ -73,6 +74,8 @@ function levelOrderTraversalHelper(node, childrenArr, outputArray) {
         // TODO do we need this reference?
         parent: currentNodeParentElementName,
         obj: node,
+        type: type,
+        color: color,
       });
     }
     if (!isLeaf) {
@@ -108,6 +111,69 @@ function levelOrderTraversalHelper(node, childrenArr, outputArray) {
   }
 }
 
+function determineType(node) {
+  const document = 'HTML';
+  const docMetadata = new Set(['HEAD', 'TITLE', 'BASE', 'LINK', 'META', 'STYLE']);
+  const sections = new Set(['BODY', 'ARTICLE', 'SECTION', 'NAV', 'ASIDE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'HGROUP', 'HEADER', 'FOOTER', 'ADDRESS']);
+  const grouping = new Set(['P', 'HR', 'PRE', 'BLOCKQUOTE', 'OL', 'UL', 'MENU', 'LI', 'DL', 'DT', 'DD', 'FIGURE', 'FIGCAPTION', 'MAIN', 'DIV']);
+  const textSemantics = new Set(['A', 'EM', 'STRONG', 'SMALL', 'S', 'CITE', 'Q', 'DFN', 'ABBR', 'RUBY', 'RT', 'RP', 'DATA', 'TIME', 'CODE', 'VAR', 'SAMP', 'KBD', 'SUB', 'SUP', 'I', 'B', 'U', 'MARK', 'BDI', 'BDO', 'SPAN', 'BR', 'WBR']);
+  const links = new Set(['AREA', 'ALTERNATE', 'AUTHOR', 'BOOKMARK', 'CANONICAL', 'DNS-PREFETCH', 'EXTERNAL', 'HELP', 'ICON', 'LICENSE', 'MANIFEST', 'MODULEPRELOAD', 'NOFOLLOW', 'NOREFERRER', 'OPENER', 'PINGBACK', 'PRECONNECT', 'PREFETCH', 'PRELOAD', 'PRERENDER', 'SEARCH', 'STYLESHEET', 'TAG', 'NEXT', 'PREV']);
+  const edits = new Set(['INS', 'DEL']);
+  const embeddedContent = new Set(['PICTURE', 'SOURCE', 'IMG', 'SOURCE', 'LINK', 'IFRAME', 'EMBED', 'OBJECT', 'PARAM', 'VIDEO', 'AUDIO', 'TRACK', 'MAP', 'AREA']);
+  const tabularData = new Set(['TABLE', 'CAPTION', 'COLGROUP', 'COL', 'TBODY', 'THEAD', 'TFOOT', 'TR', 'TD', 'TH']);
+  const forms = new Set(['FORM', 'LABEL', 'INPUT', 'BUTTON', 'SELECT', 'DATALIST']);
+
+  let type;
+  let color;
+
+  switch (true) {
+    case document === node:
+      type = 'Document Type';
+      color = '#FFFFFF';
+      break;
+    case docMetadata.has(node):
+      type = 'Document Metadata';
+      color = '#7CA982';
+      break;
+    case sections.has(node):
+      type = 'Sections';
+      color = '#E2C2FF';
+      break;
+    case grouping.has(node):
+      type = 'Grouping Content';
+      color = '#A7ADC6';
+      break;
+    case textSemantics.has(node):
+      type = 'Text-Level Semantics';
+      color = '#5BC0EB';
+      break;
+    case links.has(node):
+      type = 'Links';
+      color = '#F4F4F9';
+      break;
+    case edits.has(node):
+      type = 'Edits';
+      color = '#F3D9B1';
+      break;
+    case embeddedContent.has(node):
+      type = 'Embedded Content';
+      color = '#311E10';
+      break;
+    case tabularData.has(node):
+      type = 'Tabular Data';
+      color = '#759AAB';
+      break;
+    case forms.has(node):
+      type = 'Forms';
+      color = '#FFE787';
+      break;
+    default:
+      type = 'Other';
+      color = '#3066BE';
+  }
+  return {'type': type, 'color': color};
+}
+
 // eslint-disable-next-line no-unused-vars
 function liveUpdate() {
   const userInputString = document.getElementById('html-input-box').value;
@@ -118,3 +184,4 @@ function liveUpdate() {
     generateDOMTree(userInputString);
   }
 }
+

--- a/js/visualize.js
+++ b/js/visualize.js
@@ -1,98 +1,245 @@
 /* eslint-disable require-jsdoc */
-'use strict';
+// eslint-disable-next-line require-jsdoc
 
-function createAndAppendDOMTree(root) {
-  const margin = {top: 100, right: 200, bottom: 30, left: 100};
-  const width = 960 - margin.right - margin.left;
-  const height = 500 - margin.top - margin.bottom;
-  let i = 0;
-
-  const svg = d3
-      .select('div#output-container')
-      .append('svg')
-      .attr('width', width + margin.right + margin.left)
-      .attr('height', height + margin.top + margin.bottom)
-      .append('g')
-      .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
-
-  const tree = d3.tree().size([height, width]);
-  const treeRoot = d3.hierarchy(root);
-  tree(treeRoot);
-  const nodes = treeRoot.descendants();
-  nodes.forEach(function(d) {
-    d.y = d.depth * 100;
-  });
-  const links = treeRoot.links();
-  const node = svg.selectAll('g.node').data(nodes, function(d) {
-    return d.id || (d.id = i++);
-  });
-
-  const nodeEnter = node
-      .enter()
-      .append('g')
-      .attr('class', 'node')
-      .attr('transform', function(d) {
-        return 'translate(' + d.x + ',' + d.y + ')';
-      })
-      .on('collapseNodes', collapseNodes);
-
-  nodeEnter.append('circle').attr('r', 10);
-
-  nodeEnter
-      .append('text')
-      .attr('y', function(d) {
-        return d.children || d._children ? -18 : 18;
-      })
-      .attr('dy', '.35em')
-      .attr('text-anchor', 'middle')
-      .text(function(d) {
-        return d.data.name;
-      })
-      .style('fill', 'black');
-
-  const link = svg.selectAll('path.link').data(links, function(d) {
-    return d.target.id;
-  });
-
-  link
-      .enter()
-      .insert('path', 'g')
-      .attr('class', 'link')
-      .attr('d', createDiagonal);
-}
-function createDiagonal(d) {
-  return (
-    'M' +
-    d.source.x +
-    ',' +
-    d.source.y +
-    'C' +
-    (d.source.x + d.target.x) / 2 +
-    ',' +
-    d.source.y +
-    ' ' +
-    (d.source.x + d.target.x) / 2 +
-    ',' +
-    d.target.y +
-    ' ' +
-    d.target.x +
-    ',' +
-    d.target.y
-  );
-}
-
-function collapseNodes(d) {
-  if (d.children) {
-    d._children = d.children;
-    d.children = null;
-  } else {
-    d.children = d._children;
-    d._children = null;
+class DOMTree {
+  constructor(data) {
+    this.data = data;
+    this.svgWidth = screen.availWidth / 2.1;
+    this.svgHeight = screen.availHeight * .7; ;
+    this.duration = 500;
+    // TODO remove function call that doesn't set something to a variable in constructor
+    this.createAndAppendDOMTree(data);
   }
-  createAndAppendDOMTree(d);
-}
 
-// eslint-disable-next-line no-unused-vars
-function removeNodes() {
-  d3.select('svg').remove();
+  createAndAppendDOMTree(root) {
+    const initialX = this.svgWidth / 2;
+    const initialY = this.svgHeight * .05;
+    const zoomExtent = d3.zoom().scaleExtent([1/32, 4]).on('zoom', zoomed);
+    this.transScale = 1;
+
+    const svg = d3.select('div#output-container')
+        .append('svg').attr('width', this.svgWidth)
+        .attr('height', this.svgHeight)
+        .attr('class', 'graph-svg-component').call(zoomExtent)
+        .call(d3.zoom().transform, d3.zoomIdentity.translate(initialX, initialY)
+            .scale(this.transScale)).append('g')
+        .attr('transform', 'translate(' + initialX + ',' + initialY + ')');
+
+    this.plot = svg;
+
+    function zoomed(event) {
+      svg.attr('transform', event.transform);
+    }
+    // TODO: Bug - some node are still off-centered
+    this.tree = d3.tree().nodeSize([80, 20]);
+    this.treeRoot = d3.hierarchy(root[0], function(d) {
+      return d.children;
+    });
+    this.treeRoot.x0 = 0;
+    this.treeRoot.y0 = 0;
+
+    this.update(this.treeRoot);
+  }
+
+  update(root) {
+    let i = 0;
+    // TODO: Change depth for media queries
+    const treeLevelPadding = 100;
+    this.treeData = this.tree(this.treeRoot);
+    const nodes = this.treeData.descendants();
+    const links = this.treeData.descendants().slice(1);
+    nodes.forEach(function(d) {
+      d.y = d.depth * treeLevelPadding;
+    });
+
+    const node = this.plot.selectAll('g.node').data(nodes, function(d) {
+      return d.id || (d.id = ++i);
+    });
+
+    const tooltip = d3.select('div#output-container')
+        .append('div').attr('class', 'tooltip').style('opacity', 0);
+
+    // Nodes Section
+    const nodeEnter = node
+        .enter()
+        .append('g')
+        .attr('class', 'node')
+        .attr('transform', function(d) {
+          return 'translate(' + (root.x0) + ',' + root.y0 + ')';
+        }).on('click', (e, d) => {
+          if (d.children) {
+            d._children = d.children;
+            d.children = null;
+          } else {
+            d.children = d._children;
+            d._children = null;
+          }
+          d.clicked = true;
+          this.update(d);
+        }).on('mouseover', function(event, d) {
+          const g = d3.select(this)
+          const nodeText = g._groups[0][0].textContent;
+          const nodeType = g._groups[0][0].__data__.data.type;
+          tooltip.html(`${nodeText.bold()} HTML Type: ${nodeType}`)
+              .style('background-color', 'tan')
+              .style('border', '1px solid black')
+              .style('padding', '2px')
+              .style('top', event.pageY + 10 + 'px')
+              .style('left', event.pageX + 10 + 'px')
+              .style('opacity', 1).on('mouseout', function() {
+                tooltip.style('opacity', 0);
+              });
+        });
+
+    // TODO: Size rectangle height and width by some factor of svgHeight and svgWidth
+    // const rectH = this.svgHeight * .025;
+    // const rectW = this.svgWidth * .05;
+
+    const rectH = 35;
+    const rectW = 25;
+
+
+    nodeEnter.append('rect')
+        .attr('class', 'node')
+        .attr('width', rectW)
+        .attr('height', rectH)
+        .attr('rx', '0')
+        .style('stroke', function(d) {
+          return d.type;
+        });
+
+    nodeEnter.append('text')
+        .text(function(d) {
+          return d.data.name;
+        })
+        .attr('x', function(d) {
+          const textElement = d3.select(this.parentNode).select('text').node();
+          const bbox = textElement.getBBox();
+          return (rectW / 2) - (bbox.width / 2);
+        })
+        .attr('y', rectH / 2)
+        .attr('text-anchor', function(d) {
+          return 'middle';
+        });
+    const nodeUpdate = nodeEnter.merge(node);
+
+    // TODO: Figure out how to get rid of starting animation
+    nodeUpdate.transition()
+        .duration(this.duration)
+        .attr('transform', function(d) {
+          return 'translate(' + d.x + ',' + d.y + ')';
+        });
+
+    // TODO: Size rectangle padding by some factor of svgHeight and svgWidth
+    const nodeWidths = {};
+
+    const horizontalPadding = 25;
+    const verticalPadding = 10;
+    nodeUpdate.select('rect')
+        .attr('rx', 3)
+        .attr('ry', 3)
+        .attr('x', function(d) {
+          const textElement = d3.select(this.parentNode).select('text').node();
+          const bbox = textElement.getBBox();
+          bbox.x -= horizontalPadding / 2;
+          return bbox.x;
+        })
+        .attr('y', function(d) {
+          const textElement = d3.select(this.parentNode).select('text').node();
+          const bbox = textElement.getBBox();
+          bbox.y -= verticalPadding / 2;
+          return bbox.y;
+        })
+        .attr('stroke', 'black')
+        .attr('stroke-width', 1)
+        .attr('width', function(d) {
+          const textElement = d3.select(this.parentNode).select('text').node();
+          const bbox = textElement.getBBox();
+          bbox.width += horizontalPadding;
+          if (nodeWidths[d.depth] === undefined) {
+            nodeWidths[d.depth] = bbox.width;
+          }
+          else {
+            nodeWidths[d.depth] += bbox.width;
+          }
+          return bbox.width;
+        })
+        .attr('height', function(d) {
+          const textElement = d3.select(this.parentNode).select('text').node();
+          const bbox = textElement.getBBox();
+          bbox.height += verticalPadding;
+          return bbox.height;
+        })
+        .style('fill', function(d) {
+          return d._children ? '#fff' : d.data.color;
+        });
+
+    //TODO: Set initial zoom scaling based on max width of graph
+
+    let maxWidth = 0;
+
+    for (const width in nodeWidths) {
+      if (nodeWidths[width] > maxWidth) {
+        maxWidth = nodeWidths[width];
+      }
+    }
+
+
+    const nodeExit = node.exit().transition()
+        .duration(this.duration)
+        .attr('transform', function(d) {
+          return 'translate(' + root.x + ',' + root.y + ')';
+        })
+        .remove();
+
+
+    nodeExit.select('rect')
+        .attr('width', rectW)
+        .attr('height', rectH)
+        .attr('stroke', 'black')
+        .attr('stroke-width', 1);
+
+    nodeExit.select('text')
+        .style('fill-opacity', 1e-6);
+
+    // Links Section
+
+    // TODO: Bug - when expanding a collapsed node, the edges appear before the nodes are transitioned into position
+    const link = this.plot.selectAll('path.link')
+        .data(links, function(d) {
+          return d.id;
+        });
+
+    const linkEnter = link.enter().insert('path', 'g')
+        .attr('class', 'link')
+        .attr('d', function(d) {
+          const o = {x: root.x0, y: root.y0};
+          return diagonal(o, o);
+        });
+
+    const linkUpdate = linkEnter
+        .merge(link);
+
+    linkUpdate.transition()
+        .duration(this.duration)
+        .attr('d', function(d) {
+          return diagonal(d, d.parent);
+        });
+
+    link.exit().transition()
+        .duration(this.duration)
+        .attr('d', function(d) {
+          const o = {x: root.x, y: root.y};
+          return diagonal(o, o);
+        })
+        .remove();
+
+    function diagonal(s, d) {
+      const path = `M ${s.x} ${s.y}
+        C ${(s.x + d.x) / 2} ${s.y},
+          ${(s.x + d.x) / 2} ${d.y},
+          ${d.x} ${d.y}`;
+      return path;
+    }
+  }
 }

--- a/style.css
+++ b/style.css
@@ -24,11 +24,6 @@ body {
   cursor: pointer;
 }
 
-.node circle {
-  stroke: steelblue;
-  fill: #FFFFFF;
-}
-
 .link {
   fill: none;
   stroke: black;


### PR DESCRIPTION
Based on #42 

In this PR, we introduce multiple changes to the UI/UX of the DOM Visualizer. Refer to below for the changes.

1. Zoom: We added a zoom feature which allows the user to drag to switch the POV of the chart and zoom in/out changing the view of the chart (scale).
2. Node spacing: We use the d3 property bbox to correctly determine how far apart the nodes on the chart should be so that no two nodes intersect.
3. Tooltip: Users can now hover over a node to see information about its HTML type. Users can also move their cursor downwards to exit out of the view. 
4. Color-coordinating: Nodes are now color coordinated based on their HTML type as specified on [HTML Spec](https://html.spec.whatwg.org/) 